### PR TITLE
Use cached data when get from consul failed.

### DIFF
--- a/lib/confex_consul/local_cache.ex
+++ b/lib/confex_consul/local_cache.ex
@@ -75,7 +75,7 @@ defmodule ConfexConsul.LocalCache do
        when is_binary(consul_key) do
     case ConfexConsul.ConsulKv.get_value(consul_key) do
       {:ok, _} = value -> put(consul_key, value)
-      _ -> put(consul_key, {:ok, default_value})
+      _ -> maybe_put_default_value(consul_key, default_value)
     end
   end
 
@@ -86,5 +86,12 @@ defmodule ConfexConsul.LocalCache do
 
   defp refresh_cache_by_consul_key({{:via, ConfexConsul}, _type, consul_key, default_value}) do
     refresh_cache_by_consul_key({{:via, ConfexConsul}, consul_key, default_value})
+  end
+
+  defp maybe_put_default_value(consul_key, default_value) do
+    case get(consul_key) do
+      {:hit, _value} -> true
+      :miss -> put(consul_key, {:ok, default_value})
+    end
   end
 end


### PR DESCRIPTION
We synchronise the configuration from the consul KV store at regular intervals then cache the config value.
When request consul KV failed, what value should we use for fallback?
1. If there is data in the cache, it means we have synced it before and we can continue to use the previously cached data. This is based on the assumption that the data in our consul KV store will not change frequently.
2.  If there is no data in the cache, it means we have synced it before, we can use the default value if it exists.