### PR TITLE
Support decode consul value.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ config :my_app,
     {:via, ConfexConsul}, "decode: my_json_key", %{"default_value" => 1}
   }
 ```
+Note that it only support JSON now(Consul KV supports JSON, HCL and YAML).
 
 ### Config for consul_kv
 The [consul_kv](https://github.com/elixir-consul/consul_kv) is a dependency library that sends requests to Consul KV Store. We can modify it's config:

--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ config :my_app,
   consul_config: {{:via, ConfexConsul}, "consul_my_key"}
 ```
 
+This adapter support to decode the value from Consul KV Store by add a prefix "decode: " for the key:
+```elixir
+config :my_app,
+  consul_json_config: {
+    {:via, ConfexConsul}, "decode: my_json_key", %{"default_value" => 1}
+  }
+```
+
 ### Config for consul_kv
 The [consul_kv](https://github.com/elixir-consul/consul_kv) is a dependency library that sends requests to Consul KV Store. We can modify it's config:
 ```elixir

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,6 +1,7 @@
 import Config
 
-prefix = "test_confex_consul_#{:erlang.system_info(:otp_release)}_#{System.version()}/"
+prefix = "test_confex_consul_#{:erlang.system_info(:otp_release)}_#{System.version()}"
+json_prefix = "test_confex_consul_json_#{:erlang.system_info(:otp_release)}_#{System.version()}"
 
 config :confex_consul,
   apps: [:confex_consul],
@@ -9,6 +10,14 @@ config :confex_consul,
   key_with_default: {{:via, ConfexConsul}, "#{prefix}/key_2", "default_value_2"},
   type_with_key: {{:via, ConfexConsul}, :string, "#{prefix}/key_3"},
   type_with_key_with_default: {{:via, ConfexConsul}, :string, "#{prefix}/key_4", "default_value_4"}
+
+config :confex_consul,
+  json_only_key: {{:via, ConfexConsul}, "decode: #{json_prefix}/key_1"},
+  json_key_with_default:
+    {{:via, ConfexConsul}, "decode: #{json_prefix}/key_2", %{"default_value_2" => true}},
+  json_type_with_key: {{:via, ConfexConsul}, :string, "decode: #{json_prefix}/key_3"},
+  json_type_with_key_with_default:
+    {{:via, ConfexConsul}, :string, "decode: #{json_prefix}/key_4", %{"default_value_4" => false}}
 
 config :consul_kv,
   consul_recv_timeout: 1000,

--- a/lib/confex_consul.ex
+++ b/lib/confex_consul.ex
@@ -3,30 +3,33 @@ defmodule ConfexConsul do
   Documentation for `ConfexConsul`.
   """
 
+  require Logger
+
   @behaviour Confex.Adapter
 
   @impl Confex.Adapter
-  def fetch_value(consul_key) do
-    case ConfexConsul.LocalCache.get(consul_key) do
+  def fetch_value(key) do
+    case ConfexConsul.LocalCache.get(key) do
       {:hit, value} -> value
-      :miss -> get_from_consul_and_cache(consul_key)
+      :miss -> get_from_consul_and_cache(key)
     end
   end
 
   @doc false
-  defp get_from_consul_and_cache(consul_key) do
-    consul_key
-    |> ConfexConsul.ConsulKv.get_value()
-    |> write_cache_and_return(consul_key)
+  defp get_from_consul_and_cache(key) do
+    with {:ok, value} <- ConfexConsul.ConsulKv.get_value(key) do
+      write_cache_and_return(key, {:ok, value})
+    else
+      {:error, reason} ->
+        Logger.error("<#{__MODULE__}> get_from_consul_and_cache error: #{inspect(reason)}")
+
+        :error
+    end
   end
 
   @doc false
-  defp write_cache_and_return({:ok, value}, consul_key) do
-    ConfexConsul.LocalCache.put(consul_key, {:ok, value})
-    {:ok, value}
-  end
-
-  defp write_cache_and_return(other, _) do
-    other
+  defp write_cache_and_return(key, value) do
+    ConfexConsul.LocalCache.put(key, value)
+    value
   end
 end

--- a/lib/confex_consul.ex
+++ b/lib/confex_consul.ex
@@ -17,19 +17,14 @@ defmodule ConfexConsul do
 
   @doc false
   defp get_from_consul_and_cache(key) do
-    with {:ok, value} <- ConfexConsul.ConsulKv.get_value(key) do
-      write_cache_and_return(key, {:ok, value})
+    with {:ok, value} <- ConfexConsul.ConsulKv.get_value(key),
+         _ <- ConfexConsul.LocalCache.put(key, {:ok, value}) do
+      {:ok, value}
     else
       {:error, reason} ->
         Logger.error("<#{__MODULE__}> get_from_consul_and_cache error: #{inspect(reason)}")
 
         :error
     end
-  end
-
-  @doc false
-  defp write_cache_and_return(key, value) do
-    ConfexConsul.LocalCache.put(key, value)
-    value
   end
 end

--- a/lib/confex_consul/consul_kv.ex
+++ b/lib/confex_consul/consul_kv.ex
@@ -2,6 +2,12 @@ defmodule ConfexConsul.ConsulKv do
   @moduledoc false
 
   @spec get_value(String.t()) :: {:ok, any()} | {:error, any()}
+  def get_value("decode: " <> consul_key) do
+    with {:ok, value} <- get_value(consul_key) do
+      Jason.decode(value)
+    end
+  end
+
   def get_value(consul_key) do
     case ConsulKv.single_get(consul_key) do
       {:ok, %ConsulKv{value: value}} -> {:ok, value}

--- a/lib/confex_consul/local_cache.ex
+++ b/lib/confex_consul/local_cache.ex
@@ -82,10 +82,6 @@ defmodule ConfexConsul.LocalCache do
     refresh_cache_by_key(key)
   end
 
-  defp refresh_cache_by_key({{:via, ConfexConsul}, [:decode, _] = key, default_value}) do
-    refresh_cache_by_key(key, default_value)
-  end
-
   defp refresh_cache_by_key({{:via, ConfexConsul}, key, default_value}) when is_binary(key) do
     refresh_cache_by_key(key, default_value)
   end

--- a/test/confex_consul/consul_kv_test.exs
+++ b/test/confex_consul/consul_kv_test.exs
@@ -1,0 +1,27 @@
+defmodule ConfexConsul.ConsulKvTest do
+  use ExUnit.Case, async: true
+
+  @prefix "test_consul_kv_#{:erlang.system_info(:otp_release)}_#{System.version()}/"
+
+  setup do
+    _ = ConsulKv.recurse_delete(@prefix)
+    :ok
+  end
+
+  describe "get_value" do
+    test "by string key" do
+      key = @prefix <> "string_key"
+      {:ok, true} = ConsulKv.put(key, "v1")
+      assert {:ok, "v1"} = ConfexConsul.ConsulKv.get_value(key)
+    end
+
+    test "by decode key" do
+      key = @prefix <> "json_key"
+      {:ok, true} = ConsulKv.put(key, "{\"a\":1,\"b\":2,\"c\":3}")
+      assert {:ok, "{\"a\":1,\"b\":2,\"c\":3}"} = ConfexConsul.ConsulKv.get_value(key)
+
+      assert {:ok, %{"a" => 1, "b" => 2, "c" => 3}} =
+               ConfexConsul.ConsulKv.get_value("decode: #{key}")
+    end
+  end
+end

--- a/test/confex_consul_test.exs
+++ b/test/confex_consul_test.exs
@@ -1,18 +1,20 @@
 defmodule ConfexConsulTest do
   use ExUnit.Case
 
-  @prefix "test_confex_consul_#{:erlang.system_info(:otp_release)}_#{System.version()}/"
+  @prefix "test_confex_consul_#{:erlang.system_info(:otp_release)}_#{System.version()}"
+  @json_prefix "test_confex_consul_json_#{:erlang.system_info(:otp_release)}_#{System.version()}"
 
   setup do
     _ = ConsulKv.recurse_delete(@prefix)
+    _ = ConsulKv.recurse_delete(@json_prefix)
     _ = :ets.delete_all_objects(ConfexConsul.LocalCache)
     :ok
   end
 
-  test "fetch value" do
+  test "fetch string value" do
     key = "#{@prefix}/key_1"
     assert nil == Confex.get_env(:confex_consul, :only_key)
-    assert {:error, _} = ConfexConsul.fetch_value(key)
+    assert :error = ConfexConsul.fetch_value(key)
     assert :miss == ConfexConsul.LocalCache.get(key)
     # put kv
     assert {:ok, true} == ConsulKv.put(key, "v1")
@@ -21,23 +23,55 @@ defmodule ConfexConsulTest do
     assert "v1" == Confex.get_env(:confex_consul, :only_key)
   end
 
-  describe "auto refresh cache" do
-    test "get default value when no value on consul" do
+  test "fetch json value" do
+    consul_key = "#{@json_prefix}/key_1"
+    key = "decode: #{consul_key}"
+    json = %{"a" => 1, "b" => %{"c" => 2}}
+    encoded_json = Jason.encode!(%{"a" => 1, "b" => %{"c" => 2}})
+
+    assert {:ok, true} == ConsulKv.put(consul_key, encoded_json)
+    assert {:ok, json} == ConfexConsul.fetch_value(key)
+    assert {:hit, {:ok, json}} == ConfexConsul.LocalCache.get(key)
+    assert json == Confex.get_env(:confex_consul, :json_only_key)
+  end
+
+  describe "auto refresh values cache" do
+    test "get default value from cache" do
       ConfexConsul.LocalCache.refresh_cache()
-      # default value
       # cache
       assert :miss == ConfexConsul.LocalCache.get("#{@prefix}/key_1")
       assert {:hit, {:ok, "default_value_2"}} == ConfexConsul.LocalCache.get("#{@prefix}/key_2")
       assert :miss == ConfexConsul.LocalCache.get("#{@prefix}/key_3")
       assert {:hit, {:ok, "default_value_4"}} == ConfexConsul.LocalCache.get("#{@prefix}/key_4")
-      # confex
+
+      assert :miss == ConfexConsul.LocalCache.get("decode: #{@json_prefix}/key_1")
+
+      assert {:hit, {:ok, %{"default_value_2" => true}}} ==
+               ConfexConsul.LocalCache.get("decode: #{@json_prefix}/key_2")
+
+      assert :miss == ConfexConsul.LocalCache.get("decode: #{@json_prefix}/key_3")
+
+      assert {:hit, {:ok, %{"default_value_4" => false}}} ==
+               ConfexConsul.LocalCache.get("decode: #{@json_prefix}/key_4")
+    end
+
+    test "get default config value from cache" do
+      ConfexConsul.LocalCache.refresh_cache()
+
       assert nil == Confex.get_env(:confex_consul, :only_key)
       assert "default_value_2" == Confex.get_env(:confex_consul, :key_with_default)
       assert nil == Confex.get_env(:confex_consul, :type_with_key)
       assert "default_value_4" == Confex.get_env(:confex_consul, :type_with_key_with_default)
+
+      assert nil == Confex.get_env(:confex_consul, :json_only_key)
+      assert %{"default_value_2" => true} == Confex.get_env(:confex_consul, :json_key_with_default)
+      assert nil == Confex.get_env(:confex_consul, :json_type_with_key)
+
+      assert %{"default_value_4" => false} ==
+               Confex.get_env(:confex_consul, :json_type_with_key_with_default)
     end
 
-    test "get cached values when get values from consul failed" do
+    test "get cached strings values when get values from consul failed" do
       ConsulKv.put("#{@prefix}/key_1", "v1")
       ConsulKv.put("#{@prefix}/key_2", "v2")
       ConsulKv.put("#{@prefix}/key_3", "v3")
@@ -60,6 +94,34 @@ defmodule ConfexConsulTest do
       assert {:hit, {:ok, "v2"}} == ConfexConsul.LocalCache.get("#{@prefix}/key_2")
       assert {:hit, {:ok, "v3"}} == ConfexConsul.LocalCache.get("#{@prefix}/key_3")
       assert {:hit, {:ok, "v4"}} == ConfexConsul.LocalCache.get("#{@prefix}/key_4")
+    end
+
+    test "get cached decoded values when get values from consul failed" do
+      json = %{"a" => 1, "b" => %{"c" => 2}}
+      encoded_json = Jason.encode!(%{"a" => 1, "b" => %{"c" => 2}})
+
+      ConsulKv.put("#{@json_prefix}/key_1", encoded_json)
+      ConsulKv.put("#{@json_prefix}/key_2", encoded_json)
+      ConsulKv.put("#{@json_prefix}/key_3", encoded_json)
+      ConsulKv.put("#{@json_prefix}/key_4", encoded_json)
+
+      assert json == Confex.get_env(:confex_consul, :json_only_key)
+      assert json == Confex.get_env(:confex_consul, :json_key_with_default)
+      assert json == Confex.get_env(:confex_consul, :json_type_with_key)
+      assert json == Confex.get_env(:confex_consul, :json_type_with_key_with_default)
+
+      assert {:hit, {:ok, json}} == ConfexConsul.LocalCache.get("decode: #{@json_prefix}/key_1")
+      assert {:hit, {:ok, json}} == ConfexConsul.LocalCache.get("decode: #{@json_prefix}/key_2")
+      assert {:hit, {:ok, json}} == ConfexConsul.LocalCache.get("decode: #{@json_prefix}/key_3")
+      assert {:hit, {:ok, json}} == ConfexConsul.LocalCache.get("decode: #{@json_prefix}/key_4")
+
+      _ = ConsulKv.recurse_delete(@json_prefix)
+      ConfexConsul.LocalCache.refresh_cache()
+
+      assert {:hit, {:ok, json}} == ConfexConsul.LocalCache.get("decode: #{@json_prefix}/key_1")
+      assert {:hit, {:ok, json}} == ConfexConsul.LocalCache.get("decode: #{@json_prefix}/key_2")
+      assert {:hit, {:ok, json}} == ConfexConsul.LocalCache.get("decode: #{@json_prefix}/key_3")
+      assert {:hit, {:ok, json}} == ConfexConsul.LocalCache.get("decode: #{@json_prefix}/key_4")
     end
   end
 end


### PR DESCRIPTION
Support decode value by adding key prefix `"decode: "`.
``` elixir
config :my_app,
  consul_json_config: {
    {:via, ConfexConsul}, "decode: my_json_key", %{"default_value" => 1}
  }
```
Why use the prefix `"decode: "`?
There will be a [function mismatched](https://github.com/Nebo15/confex/blob/master/lib/confex/resolver.ex#L144) when using a key like `{:decode, "my_key"}`. 
There will be a [function mismatched](https://github.com/Nebo15/confex/blob/master/lib/confex/resolver.ex#L174) when using a key like `["decode", "my_key"]`. 

For now, the decoding only support JSON.